### PR TITLE
fix test set boundaries for conll++ dataset

### DIFF
--- a/ner_dataset/CoNLL++/conllpp_test.txt
+++ b/ner_dataset/CoNLL++/conllpp_test.txt
@@ -440,8 +440,8 @@ from IN I-PP O
 one CD I-NP O
 game NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RUGBY NNP I-NP B-ORG
 UNION NN I-NP I-ORG
@@ -723,8 +723,8 @@ Moscardi NNP I-NP I-PER
 Andrea NNP I-NP B-PER
 Castellani NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -1125,8 +1125,8 @@ Zaher NNP I-NP I-PER
 Nader NNP I-NP B-PER
 Jokhadar NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 FREESTYLE NNP I-NP O
 SKIING-WORLD NNP I-NP B-MISC
@@ -1318,8 +1318,8 @@ Allais NNPS I-NP I-PER
 France NNP I-NP B-LOC
 ) ) O O
 21.58 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -1466,8 +1466,8 @@ China NNP I-NP B-LOC
 0 CD I-NP O
 2 CD I-NP O
 0 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -1868,8 +1868,8 @@ December NNP I-NP O
 in IN I-PP O
 Karachi NNP I-NP B-LOC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -1903,8 +1903,8 @@ Plymouth NN I-NP B-ORG
 4 CD I-NP O
 Exeter NNP I-NP B-ORG
 1 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -2055,8 +2055,8 @@ commitment NN I-NP O
 to TO I-PP O
 Udinese NNP I-NP B-ORG
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -2225,8 +2225,8 @@ Middlesbrough NNP I-NP B-ORG
 on IN I-PP O
 Saturday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BASKETBALL NNP I-NP O
 - : O O
@@ -2504,8 +2504,8 @@ Russia NNP I-NP B-LOC
 2 CD I-NP O
 7 CD I-NP O
 11 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RUGBY NNP I-NP B-ORG
 UNION NN I-NP I-ORG
@@ -3039,8 +3039,8 @@ Caputo NNP I-NP I-PER
 Dan NNP I-NP B-PER
 Crowley NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 GOLF NN I-NP O
 - : O O
@@ -3225,8 +3225,8 @@ Ian NNP I-NP B-PER
 Dougan NNP I-NP I-PER
 73 CD I-NP O
 69 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -3473,8 +3473,8 @@ Ion NNP I-NP I-PER
 . . O O
 
 REUTER NNP I-NP B-ORG
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -3513,8 +3513,8 @@ Portuguesa NNP I-NP B-ORG
 Atletico NNP I-NP B-ORG
 Mineiro NNP I-NP I-ORG
 0 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -3860,8 +3860,8 @@ World NNP I-NP B-MISC
 Series NNP I-NP I-MISC
 tournament NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -4180,8 +4180,8 @@ by IN I-PP O
 five CD I-NP O
 wickets NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -4249,8 +4249,8 @@ not RB I-VP O
 out RP I-PRT O
 ) ) O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -4291,8 +4291,8 @@ Australia NNP I-NP B-LOC
 on IN I-PP O
 Friday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -4352,8 +4352,8 @@ DiVenuto NNP I-NP I-PER
 v FW I-NP O
 Victoria NNP I-NP B-ORG
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -4741,8 +4741,8 @@ World NNP I-NP B-MISC
 Series NNP I-NP I-MISC
 tournament NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -4884,8 +4884,8 @@ Holder NNP I-NP I-PER
 12th JJ I-NP O
 man NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BADMINTON NNP I-NP O
 - : O O
@@ -5167,8 +5167,8 @@ Zichao NNP I-NP I-PER
 China NNP I-NP B-LOC
 ) ) O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -5243,8 +5243,8 @@ won VBD I-VP O
 on IN I-PP O
 aggregate NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NHL NNP I-NP B-ORG
 ICE NNP I-NP O
@@ -5588,8 +5588,8 @@ COLORADO NNP I-NP B-LOC
 OTTAWA NNP I-NP B-ORG
 AT NNP I-NP O
 EDMONTON NNP I-NP B-LOC
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NHL NNP I-NP B-ORG
 ICE NNP I-NP O
@@ -5680,8 +5680,8 @@ Bay NNP I-NP I-ORG
 LOS NNP I-NP B-ORG
 ANGELES NNP I-NP I-ORG
 1 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NFL NNP I-NP B-ORG
 AMERICAN NNP I-NP O
@@ -6082,8 +6082,8 @@ on IN I-PP O
 seven CD I-NP O
 carries VBZ I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NBA NNP I-NP B-ORG
 BASKETBALL NNP I-NP O
@@ -6397,8 +6397,8 @@ ORLANDO NNP I-NP B-ORG
 AT NNP I-NP O
 LA NNP I-NP B-LOC
 LAKERS NNS I-NP I-LOC
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NFL NNP I-NP B-ORG
 AMERICAN NNP I-NP O
@@ -6809,8 +6809,8 @@ KANSAS NNP I-NP B-ORG
 CITY NNP I-NP I-ORG
 AT NNP I-NP O
 OAKLAND NNP I-NP B-LOC
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NFL NNP I-NP B-ORG
 AMERICAN NNP I-NP O
@@ -6844,8 +6844,8 @@ INDIANAPOLIS NNP I-NP B-ORG
 37 CD I-NP O
 Philadelphia NNP I-NP B-ORG
 10 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NCAA NNP I-NP B-ORG
 AMERICAN NNP I-NP O
@@ -7028,8 +7028,8 @@ Green NNP I-NP B-ORG
 Bay NNP I-NP I-ORG
 Packers NNPS I-NP I-ORG
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -7264,8 +7264,8 @@ Waalwijk NNP I-NP I-ORG
 18 CD I-NP O
 33 CD I-NP O
 14 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -7520,8 +7520,8 @@ Freiburg NNP I-NP I-ORG
 20 CD I-NP O
 40 CD I-NP O
 13 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -7606,8 +7606,8 @@ Gray NNP I-NP I-PER
 
 30,000 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -7663,8 +7663,8 @@ Halftime VB I-VP O
 Attendance NNP I-NP O
 5,300 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -7889,8 +7889,8 @@ Nice JJ I-ADJP B-ORG
 17 CD I-NP O
 38 CD I-NP O
 13 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -7924,8 +7924,8 @@ Germain NNP I-NP I-ORG
 1 CD I-NP O
 Nancy NNP I-NP B-ORG
 2 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -8046,8 +8046,8 @@ Halftime NNP I-NP O
 
 Attendance NNP I-NP O
 29,300 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 TENNIS NNS I-NP O
 - : O O
@@ -8106,8 +8106,8 @@ U.S. NNP I-NP B-LOC
 2-6 CD I-NP O
 6-4 CD I-NP O
 8-6 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -8386,8 +8386,8 @@ Glasgow NNP I-NP I-ORG
 Scotland NNP I-NP B-LOC
 ) ) O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NNP I-NP O
 SHOWCASE-BETTING NNP I-NP O
@@ -8670,8 +8670,8 @@ Nadal NNP I-NP I-PER
 
 Laurent NNP I-NP B-PER
 Blanc NNP I-NP I-PER
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NNP I-NP O
 SHOWCASE-FANS NNP I-NP O
@@ -8764,8 +8764,8 @@ of IN I-PP O
 alcohol NN I-NP O
 " " O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -9022,8 +9022,8 @@ Extremadura NNP I-NP B-ORG
 8 CD I-NP O
 30 CD B-NP O
 6 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -9095,8 +9095,8 @@ Jose NNP I-NP B-PER
 Luis NNP I-NP I-PER
 Caminero NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -9384,8 +9384,8 @@ the DT I-NP O
 Europoean NNP I-NP B-MISC
 Cup NNP I-NP I-MISC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 GUNMEN NNP I-NP O
 WOUND NNP I-NP O
@@ -9505,8 +9505,8 @@ United NNP I-NP I-ORG
 won VBD I-VP O
 2-0 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -10153,8 +10153,8 @@ striker NN I-NP O
 Ivan NNP B-NP B-PER
 Zamorano NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BASKETBALL NNP I-NP O
 - : O O
@@ -10268,8 +10268,8 @@ Kinder NN I-NP O
 Zoran NNP I-NP B-PER
 Savic NNP I-NP I-PER
 18 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SQUASH NNP I-NP O
 - : O O
@@ -10397,8 +10397,8 @@ player NN I-NP O
 said VBD I-VP O
 Nicol NNP I-NP B-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SQUASH NNP I-NP O
 - : O O
@@ -10465,8 +10465,8 @@ Eyles NNP I-NP B-PER
 on IN I-PP O
 Saturday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 GUNMEN NNP I-NP O
 KILL MD I-VP O
@@ -10742,8 +10742,8 @@ in IN I-PP O
 the DT I-NP O
 province NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 HAVEL NNP I-NP B-PER
 PRAISES NNPS I-NP O
@@ -11141,8 +11141,8 @@ of IN I-PP O
 the DT I-NP O
 Czechs NNPS I-NP B-MISC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RADIO NNP I-NP B-ORG
 ROMANIA NNP I-NP I-ORG
@@ -11279,8 +11279,8 @@ Bucharest NNP I-NP B-ORG
 Newsroom NNP I-NP I-ORG
 40-1 NNP I-NP O
 3120264 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CZECH NNP I-NP B-MISC
 VICE-PM NNP I-NP O
@@ -11599,8 +11599,8 @@ position NN I-NP O
 Prague NNP I-NP B-ORG
 Newsroom NNP I-NP I-ORG
 42-2-2423-0003 NNS I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 POLAND NNP I-NP B-LOC
 GOT NNP O O
@@ -12063,8 +12063,8 @@ plan NN I-NP O
 would MD I-VP O
 work VB I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 INTERVIEW-ZYWIEC NNP I-NP B-MISC
 SEES NNP I-NP O
@@ -12782,8 +12782,8 @@ Newsroom NNP I-NP I-ORG
 22 CD I-NP O
 653 CD I-NP O
 9700 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 HAVEL NNP I-NP B-PER
 HAS VBZ I-VP O
@@ -12996,8 +12996,8 @@ the DT I-NP O
 left JJ I-NP O
 lung NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 UK-US NNP I-NP B-MISC
 open JJ I-NP O
@@ -13107,8 +13107,8 @@ further JJ I-NP O
 talks NNS I-NP O
 . . O O
 " " O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Tambang VBG I-VP B-ORG
 Timah NNP I-NP I-ORG
@@ -13180,8 +13180,8 @@ Jakarta NNP I-NP B-LOC
 newsroom NN I-NP O
 +6221 CD I-NP O
 384-6364 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Telkom NN I-INTJ B-ORG
 at IN I-PP O
@@ -13251,8 +13251,8 @@ newsroom NN I-NP O
 +6221 CD I-NP O
 384-6364 RB I-ADVP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Woman NN I-NP O
 charged VBN I-VP O
@@ -13389,8 +13389,8 @@ from IN I-PP O
 Northern NNP I-NP B-LOC
 Ireland NNP I-NP I-LOC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Britain NNP I-NP B-LOC
 sets VBZ I-VP O
@@ -13867,8 +13867,8 @@ Jan. NNP I-NP O
 , , I-NP O
 1997 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Med JJ I-NP B-LOC
 oil NN I-NP O
@@ -14193,8 +14193,8 @@ into IN I-PP O
 next JJ I-NP O
 week NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 New JJ I-NP O
 meningitis NNS I-NP O
@@ -14460,8 +14460,8 @@ pensioners NNS I-NP O
 ' POS B-NP O
 lunch NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Major NNP I-NP B-PER
 's POS B-NP O
@@ -14698,8 +14698,8 @@ in IN I-PP O
 his PRP$ I-NP O
 constituency NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Electronic NNP I-NP B-ORG
 Data NNP I-NP I-ORG
@@ -14841,8 +14841,8 @@ London NNP I-NP B-ORG
 Newsroom NNP I-NP I-ORG
 +44-171-542 CD I-NP O
 7717 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RTRS NNS I-NP B-ORG
 - : O O
@@ -14923,8 +14923,8 @@ Sydney NNP I-NP B-ORG
 Newsroom NNP I-NP I-ORG
 61-2 NN I-NP O
 9373-1800 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Cricket NNP I-NP O
 - : O O
@@ -14972,8 +14972,8 @@ Pakistan NNP I-NP B-LOC
 New NNP I-NP B-LOC
 Zealand NNP I-NP I-LOC
 231 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Manitoba NNP I-NP B-ORG
 Pork NNP I-NP I-ORG
@@ -15150,8 +15150,8 @@ bureau NN I-NP O
 204-947-3548 CD I-NP O
 ) ) O O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Canadian NNP I-NP B-MISC
 West NNP I-NP O
@@ -15260,8 +15260,8 @@ Gras NNP I-NP I-PER
 3548 CD I-NP O
 ) ) O O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 New NNP I-NP B-LOC
 York NNP I-NP I-LOC
@@ -15294,8 +15294,8 @@ Desk NNP I-NP I-ORG
 212 CD I-NP O
 859 CD I-NP O
 1640 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 New NNP I-NP B-LOC
 York NNP I-NP I-LOC
@@ -15343,8 +15343,8 @@ Desk NNP I-NP I-ORG
 212 CD I-NP O
 859 CD I-NP O
 1640 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Clean NNP I-NP O
 tankers NNS I-NP O
@@ -15384,8 +15384,8 @@ Commodities NNP I-NP I-ORG
 Desk NNP I-NP I-ORG
 , , O O
 212-859-1640 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Dirty JJ I-NP O
 tanker NN I-NP O
@@ -15465,8 +15465,8 @@ Desk NNP I-NP I-ORG
 212 CD I-NP O
 859 CD I-NP O
 1640 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NYC NNP I-NP B-LOC
 Jan NNP I-NP O
@@ -15716,8 +15716,8 @@ Joan NNP I-NP B-PER
 Gralla NNP I-NP I-PER
 , , O O
 212-859-1654 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 USDA NNP I-NP B-ORG
 gross JJ I-NP O
@@ -15765,8 +15765,8 @@ value NN I-NP O
 
 - : O O
 USDA NNP I-NP B-ORG
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Wall NNP I-NP B-LOC
 St NNP I-NP I-LOC
@@ -16484,8 +16484,8 @@ Desk NNP I-NP I-ORG
 , , O O
 212-859-1734 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Russ NNP I-NP B-ORG
 Berrie NNP I-NP I-ORG
@@ -16558,8 +16558,8 @@ gift NN I-NP O
 maker NN I-NP O
 said VBD I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Zimbabwe NNP I-NP B-LOC
 executes VBZ I-VP O
@@ -16626,8 +16626,8 @@ the DT I-NP O
 death NN I-NP O
 sentence NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Multinational JJ I-NP O
 commander NN I-NP O
@@ -17408,8 +17408,8 @@ have VBP I-VP O
 been VBN I-VP O
 checking NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Mauritius NN I-NP B-LOC
 put VBN I-VP O
@@ -17564,8 +17564,8 @@ gone VBN I-VP O
 on IN I-PP O
 alert NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 U.N. NNP I-NP B-ORG
 evacuates VBZ I-VP O
@@ -17639,8 +17639,8 @@ Abidjan NNP I-NP B-LOC
 Ivory NNP I-NP B-LOC
 Coast NNP I-NP I-LOC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Senegal JJ I-NP B-LOC
 proposes VBZ I-VP O
@@ -17790,8 +17790,8 @@ my PRP$ I-NP O
 endorsement NN I-NP O
 . . O O
 " " O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Ex-minister NNP I-NP O
 , , O O
@@ -18472,8 +18472,8 @@ the DT I-NP O
 city NN I-NP O
 centre NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Five CD I-NP O
 die VBP I-VP O
@@ -18547,8 +18547,8 @@ van NNP I-NP O
 were VBD I-VP O
 killed VBN I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 WEATHER NN I-NP O
 - : O O
@@ -18593,8 +18593,8 @@ Newsroom NNP I-NP I-ORG
 +7095 CD I-NP O
 941 CD I-NP O
 8520 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Skinheads NNS I-NP O
 attack VBD I-VP O
@@ -18737,8 +18737,8 @@ available JJ I-ADJP O
 for IN I-PP O
 comment NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Albanian NNP I-NP B-MISC
 jailed VBD I-VP O
@@ -18916,8 +18916,8 @@ committed VBN I-VP O
 Gjonaj NNP I-NP B-PER
 said VBD I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Polish JJ I-NP B-MISC
 ex-communist JJ I-NP O
@@ -19136,8 +19136,8 @@ law NN I-NP O
 last JJ B-NP O
 month NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Russia NNP I-NP B-LOC
 warns VBZ I-VP O
@@ -19790,8 +19790,8 @@ Newsroom NNP I-NP I-ORG
 +7095 CD I-NP O
 941 CD I-NP O
 8520 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Estonian JJ I-NP B-MISC
 Tallinna NNP I-NP B-ORG
@@ -19917,8 +19917,8 @@ Newsroom NNP I-NP I-ORG
 +371 CD I-NP O
 721 CD I-NP O
 5240 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Russia NNP I-NP B-LOC
 ready JJ I-ADJP O
@@ -20133,8 +20133,8 @@ threaten VB I-VP O
 its PRP$ I-NP O
 security NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Yeltsin JJ I-NP B-PER
 plans NNS I-NP O
@@ -20362,8 +20362,8 @@ at IN I-PP O
 his PRP$ I-NP O
 residence NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Bomb VB I-VP O
 explodes VBZ B-VP O
@@ -20579,8 +20579,8 @@ behind IN I-PP O
 the DT I-NP O
 blast NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Bomb VB I-VP O
 explodes VBZ B-VP O
@@ -20707,8 +20707,8 @@ of IN I-PP O
 the DT I-NP O
 mosque JJ I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Hungary NNP I-NP B-LOC
 o IN I-PP O
@@ -20868,8 +20868,8 @@ newsroom NN I-NP O
 ) ) O O
 327 CD I-NP O
 4040 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Mexico NNP I-NP B-LOC
 stocks NNS I-NP O
@@ -21297,8 +21297,8 @@ to TO I-VP O
 do VB I-VP O
 . . O O
 ' '' O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Plastic NN I-NP O
 surgery NN I-NP O
@@ -21837,8 +21837,8 @@ to TO I-PP O
 normal JJ I-NP O
 now RB I-ADVP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Daily NNP I-NP O
 Argentine JJ I-NP B-MISC
@@ -21927,8 +21927,8 @@ Aires NNP I-NP I-ORG
 Newsroom NNP I-NP I-ORG
 +541 CD I-NP O
 318-0655 JJ I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Mexican JJ I-NP B-MISC
 daily JJ I-NP O
@@ -22215,8 +22215,8 @@ City NNP I-NP I-LOC
 newsroom NN I-NP O
 +525 CD B-NP O
 728-7903 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Brazil NNP I-NP B-LOC
 exam NN I-NP O
@@ -22315,8 +22315,8 @@ O UH I-INTJ B-ORG
 Globo NNP I-NP I-ORG
 said VBD I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Chile NNP I-NP B-LOC
 , , O O
@@ -22552,8 +22552,8 @@ Santiago NN I-NP B-LOC
 newsroom NN I-NP O
 +56-2-699-5595 NN I-NP O
 x211 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Indonesia NNP I-NP B-LOC
 's POS B-NP O
@@ -22965,8 +22965,8 @@ come VB I-VP O
 to TO I-PP O
 Jakarta NNP I-NP B-LOC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 China NN I-NP B-LOC
 to TO I-VP O
@@ -23080,8 +23080,8 @@ $ $ I-NP O
 8.3 CD I-NP O
 yuan NN I-NP O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Government NN I-NP O
 disperses VBZ I-VP O
@@ -23287,8 +23287,8 @@ in IN I-PP O
 the DT I-NP O
 capital NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Burmese NN I-NP B-MISC
 students NNS I-NP O
@@ -23833,8 +23833,8 @@ closed VBN I-VP O
 by IN I-PP O
 police NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Union NNP I-NP B-ORG
 leaders NNS I-NP O
@@ -24284,8 +24284,8 @@ by IN B-PP O
 the DT I-NP O
 ILO NNP I-NP B-ORG
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Indian JJ I-NP B-MISC
 rubber NN I-NP O
@@ -24604,8 +24604,8 @@ Newsroom NNP I-NP I-ORG
 ( ( O O
 65-8703305 CD I-NP O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Japan NNP I-NP B-LOC
 's POS B-NP O
@@ -25335,8 +25335,8 @@ to TO I-NP O
 five CD I-NP O
 percent NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Lebanon NNP I-NP B-LOC
 sentences NNS I-NP O
@@ -25817,8 +25817,8 @@ against IN I-PP O
 Lebanon NNP I-NP B-LOC
 " " O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Texas NNP I-NP B-LOC
 / SYM O O
@@ -25952,8 +25952,8 @@ newsdesk NN I-NP O
 8720 CD I-NP O
 ) ) O O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 USDA NNP I-NP B-ORG
 daily JJ I-NP O
@@ -26110,8 +26110,8 @@ Bull NNP I-NP O
 Thursday NNP I-NP O
 100,000 CD I-NP O
 33,000 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BALANCE NNP I-NP O
 - : O O
@@ -26268,8 +26268,8 @@ Municipal NNP I-NP I-ORG
 Desk NNP I-NP I-ORG
 , , O O
 212-859-1650 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 14 CD I-NP O
 years NNS I-NP O
@@ -26673,8 +26673,8 @@ a DT I-NP O
 347-year JJ I-NP O
 sentence NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 New NNP I-NP B-LOC
 York NNP I-NP I-LOC
@@ -26715,8 +26715,8 @@ Desk NNP I-NP I-ORG
 212 CD I-NP O
 859 CD I-NP O
 1640 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Iowa-S NNP I-NP B-LOC
 Minn NNP I-NP B-LOC
@@ -26894,8 +26894,8 @@ newsdesk NN I-NP O
 312-408-8720 CD I-NP O
 ) ) O O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Man NN I-NP O
 stole VBD I-VP O
@@ -27088,8 +27088,8 @@ breast NN I-NP O
 implant NN I-NP O
 surgery NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Canadian JJ I-NP B-MISC
 grain NN I-NP O
@@ -27339,8 +27339,8 @@ newsdesk NN I-NP O
 408 CD I-NP O
 8720 CD I-NP O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NYMEX NN I-NP B-ORG
 natgas NN I-NP O
@@ -27812,8 +27812,8 @@ York NNP I-NP I-ORG
 Power NNP I-NP I-ORG
 Desk NNP I-NP I-ORG
 +212-859-1628 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 U.S. NNP I-NP B-LOC
 barges NNS I-NP O
@@ -28007,8 +28007,8 @@ Chicago NNP I-NP B-LOC
 newsdesk NN I-NP O
 312-408 CD B-NP O
 8720 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CBOT NNP I-NP B-ORG
 grain NN I-NP O
@@ -28115,8 +28115,8 @@ Newsdesk NNP I-NP I-ORG
 312-408-8720 CD I-NP O
 ) ) O O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Clinton NN I-NP B-PER
 to TO I-VP O
@@ -28253,8 +28253,8 @@ the DT I-NP O
 spokesman NN I-NP O
 added VBD I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Action NNP I-NP O
 Performance NNP I-NP O
@@ -28352,8 +28352,8 @@ customary JJ I-NP O
 closing NN I-NP O
 conditions NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Half NN I-NP O
 of IN I-PP O
@@ -28713,8 +28713,8 @@ dog NN I-NP O
 goes VBZ I-VP O
 away RB I-ADVP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Iowa-S NNP I-NP B-LOC
 Minn NNP I-NP B-LOC
@@ -28768,8 +28768,8 @@ newsdesk NN I-NP O
 312-408-8720 CD I-NP O
 ) ) O O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Nebraska NN I-NP B-LOC
 fed VBN I-VP O
@@ -28873,8 +28873,8 @@ Choice NNP I-NP O
 lbs VBZ I-VP O
 112.00 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Four CD I-NP O
 Africans NNPS I-NP B-MISC
@@ -29216,8 +29216,8 @@ Boutros-Ghali NNP I-NP B-PER
 term NN I-NP O
 expires VBZ I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Spain NNP I-NP B-LOC
 's POS B-NP O
@@ -29333,8 +29333,8 @@ Spain NNP I-NP B-LOC
 's POS B-NP O
 constitution NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Mussolini NNP I-NP B-PER
 's POS B-NP O
@@ -29564,8 +29564,8 @@ War NNP I-NP I-MISC
 Two CD I-NP I-MISC
 followers NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 German NNP I-NP B-MISC
 Santa NNP I-NP B-PER
@@ -29647,8 +29647,8 @@ he PRP B-NP O
 was VBD I-VP O
 genuine JJ I-ADJP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Italy NN I-NP B-LOC
 commission NN I-NP O
@@ -29713,8 +29713,8 @@ Milan NNP I-NP B-LOC
 newsroom NN I-NP O
 +392 CD B-NP O
 66129502 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 EU RB I-ADVP B-ORG
 , , O O
@@ -29915,8 +29915,8 @@ at IN I-PP O
 six-monthly JJ I-NP O
 meetings NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Hindu NNP I-NP B-MISC
 party NN I-NP O
@@ -30143,8 +30143,8 @@ party NN I-NP O
 in IN I-PP O
 1991 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Indian NNP I-NP B-MISC
 Sept NNP I-NP O
@@ -30228,8 +30228,8 @@ tonnes NNS I-NP O
 and CC O O
 preliminary JJ I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 LUXEMBOURG NNP I-NP B-LOC
 CHRISTMAS NNP I-NP O
@@ -30311,8 +30311,8 @@ Fax NNP I-NP O
 2 CD I-NP O
 230 CD I-NP O
 7710 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 London NNP I-NP B-LOC
 coal NN I-NP O
@@ -30399,8 +30399,8 @@ shinc VBG I-VP O
 China NNP I-NP B-ORG
 Steel NNP I-NP I-ORG
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 UK NNP I-NP B-LOC
 bookmakers NNS I-NP O
@@ -30483,8 +30483,8 @@ Newsroom NNP I-NP I-ORG
 +44 CD I-NP O
 171 CD I-NP O
 542-7768 JJ I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Italy NNP I-NP B-LOC
 tops NNS I-NP O
@@ -30838,8 +30838,8 @@ Bonds NNP I-NP I-ORG
 +44 CD I-NP O
 171 CD I-NP O
 6320 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 OPEC NNP I-NP B-ORG
 basket NN I-NP O
@@ -30934,8 +30934,8 @@ Newsroom NNP I-NP I-ORG
 171 CD I-NP O
 542 CD I-NP O
 7630 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Relations NNS I-NP O
 between IN I-PP O
@@ -31079,8 +31079,8 @@ constituencies NNS I-NP O
 on IN I-PP O
 Friday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Two CD I-NP O
 dead JJ I-NP O
@@ -31309,8 +31309,8 @@ later RB I-ADVP O
 on IN I-PP O
 Friday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 PLO NNP I-NP B-ORG
 says VBZ I-VP O
@@ -31698,8 +31698,8 @@ the DT I-NP O
 religious JJ I-NP O
 observance NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Turkey NNP I-NP B-LOC
 hindered VBD I-VP O
@@ -31952,8 +31952,8 @@ the DT I-NP O
 12-year-old JJ I-NP O
 conflict NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Three CD I-NP O
 dead JJ I-NP O
@@ -32143,8 +32143,8 @@ autonomy NN I-NP O
 or CC I-NP O
 independence NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Texas NNP I-NP B-LOC
 / SYM O O
@@ -32263,8 +32263,8 @@ choice NN I-NP O
 lbs VBZ I-VP O
 66.00 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Kansas NNP I-NP B-LOC
 feedlot NN I-NP O
@@ -32381,8 +32381,8 @@ Choice NNP I-NP O
 lbs VBZ I-VP O
 67.00 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Delphis NNP I-NP B-ORG
 Hanover NNP I-NP I-ORG
@@ -32490,8 +32490,8 @@ Municipal NNP I-NP I-ORG
 Desk NNP I-NP I-ORG
 , , O O
 212-859-1650 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ACCESS NN I-NP B-MISC
 energy NN I-NP O
@@ -32692,8 +32692,8 @@ bureau NN I-NP O
 213 CD I-NP O
 380 CD I-NP O
 2014 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 U.S. NNP I-NP B-LOC
 blasts NNS I-NP O
@@ -33097,8 +33097,8 @@ four CD I-NP O
 U.S. NNP I-NP B-LOC
 citizens NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 School NNP I-NP O
 football NN I-NP O
@@ -33268,8 +33268,8 @@ a DT I-NP O
 previous JJ I-NP O
 game NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Cyberspace NN I-NP O
 squabbles NNS I-NP O
@@ -34027,8 +34027,8 @@ them PRP I-NP O
 all DT B-NP O
 ? . O O
 " " O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Italy NNP I-NP B-LOC
 evacuates VBZ I-VP O
@@ -34174,8 +34174,8 @@ one CD I-NP O
 from IN I-PP O
 Zambia NNP I-NP B-LOC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Third JJ I-NP O
 Paris NNP I-NP B-LOC
@@ -34327,8 +34327,8 @@ more JJR I-NP O
 than IN I-NP O
 160 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Italian NNP I-NP B-MISC
 President NNP I-NP O
@@ -34645,8 +34645,8 @@ Padania NNP I-NP I-LOC
 flopped VBD I-VP O
 badly RB I-ADVP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Denmark NNP I-NP B-LOC
 's POS B-NP O
@@ -34752,8 +34752,8 @@ Copenhagen NNP I-NP B-LOC
 newsroom NN I-NP O
 +45 CD I-NP O
 33969650 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Moslem NNP I-NP B-MISC
 fundamentalists NNS I-NP O
@@ -34817,8 +34817,8 @@ of IN I-PP O
 terrorists NNS I-NP O
 " " O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Belgian JJ I-NP B-MISC
 police NN I-NP O
@@ -35021,8 +35021,8 @@ $ $ I-NP O
 Belgian NNP I-NP B-MISC
 Franc NNP I-NP O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Port NN I-NP O
 conditions NNS I-NP O
@@ -35066,8 +35066,8 @@ promised VBN I-NP O
 bonus NN I-NP O
 scheme NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 German NNP I-NP B-MISC
 Jan-August NNP I-NP O
@@ -35189,8 +35189,8 @@ bags NNS I-NP O
 Hamburg NNP I-NP B-LOC
 newsroom NN I-NP O
 +49-40-41903275 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Munich NNP I-NP B-ORG
 Re NNP I-NP I-ORG
@@ -35338,8 +35338,8 @@ Newsroom NNP I-NP I-ORG
 +49 CD I-NP O
 69 CD I-NP O
 756525 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 EU NN I-NP B-ORG
 experts NNS I-NP O
@@ -35461,8 +35461,8 @@ Newsroom NNP I-NP I-ORG
 2 CD I-NP O
 287 CD I-NP O
 6800 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Frankfurt NNP I-NP B-LOC
 dollar NN I-NP O
@@ -35499,8 +35499,8 @@ no DT I-NP O
 Bundesbank NNP I-NP B-ORG
 intervention NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 John NNP I-NP B-ORG
 Lewis NNP I-NP I-ORG
@@ -35598,8 +35598,8 @@ Newsroom NNP I-NP I-ORG
 171 CD I-NP O
 542 CD I-NP O
 2774 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Timah VBN I-VP B-ORG
 at IN I-PP O
@@ -35674,8 +35674,8 @@ Jakarta NNP I-NP B-LOC
 newsroom NN I-NP O
 +6221 CD I-NP O
 384-6364 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 British JJ I-NP B-MISC
 " " O O
@@ -35952,8 +35952,8 @@ go VB I-VP O
 with IN I-PP O
 him PRP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Court NNP I-NP O
 ejects VBZ I-VP O
@@ -36239,8 +36239,8 @@ sex NN I-NP O
 with IN I-PP O
 children NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Australian JJ I-NP B-MISC
 hitman NN I-NP O
@@ -36456,8 +36456,8 @@ years NNS I-NP O
 in IN I-PP O
 prison NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NZ NNP I-NP B-LOC
 's POS B-NP O
@@ -36521,8 +36521,8 @@ formed VBN I-VP O
 by IN I-PP O
 Thursday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NZ NNP I-NP B-LOC
 's POS B-NP O
@@ -36631,8 +36631,8 @@ that DT I-NP O
 good JJ I-NP O
 " " O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RTRS NNS I-NP B-ORG
 - : O O
@@ -36872,8 +36872,8 @@ Canberra NNP I-NP B-LOC
 Bureau NNP I-NP O
 61-6 CD I-NP O
 273-2730 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Burmese NN I-NP B-MISC
 students NNS I-NP O
@@ -37090,8 +37090,8 @@ published VBN I-VP O
 in IN I-PP O
 newspapers NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Thai NNP I-NP B-MISC
 rice NN I-NP O
@@ -37211,8 +37211,8 @@ newsroom NN I-NP O
 662 CD I-NP O
 ) ) O O
 652-0642 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Chinese JJ I-NP B-MISC
 girl NN I-NP O
@@ -37311,8 +37311,8 @@ give VB I-VP O
 up RP I-PRT O
 smoking NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 South JJ I-NP B-MISC
 Korean JJ I-NP I-MISC
@@ -37436,8 +37436,8 @@ won VBD I-VP O
 next JJ I-NP O
 week NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Foreign JJ I-NP O
 planes NNS I-NP O
@@ -37581,8 +37581,8 @@ popular JJ I-ADJP O
 tourist NN I-NP O
 destinations NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 EPA NNP I-NP B-ORG
 says VBZ I-VP O
@@ -37724,8 +37724,8 @@ from IN I-PP O
 April NNP I-NP O
 1 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Sangetsu NNP I-NP B-ORG
 - : O O
@@ -37799,8 +37799,8 @@ specialising VBG I-VP O
 in IN I-PP O
 interiors NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Bre-X NNP I-NP B-ORG
 , , O O
@@ -38423,8 +38423,8 @@ development NN I-NP O
 project NN I-NP O
 " " O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Honda NNP I-NP B-MISC
 RV NN I-NP I-MISC
@@ -38508,8 +38508,8 @@ of IN I-PP O
 the DT I-NP O
 sales NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 FEATURE VB I-VP O
 - : O O
@@ -39189,8 +39189,8 @@ be VB I-VP O
 displayed VBN I-VP O
 . . O O
 " " O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Japan NNP I-NP B-LOC
 NTT NNP I-NP B-ORG
@@ -39412,8 +39412,8 @@ officials NNS I-NP O
 were VBD I-VP O
 required VBN I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 Ahold NNP I-NP B-ORG
 launches VBZ I-VP O
@@ -39606,8 +39606,8 @@ Fax NNP I-NP O
 20 CD I-NP O
 504 CD I-NP O
 504 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-WOMEN JJ I-NP O
@@ -39690,8 +39690,8 @@ the DT I-NP O
 World NNP I-NP B-MISC
 Championships NNPS I-NP I-MISC
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-WOMEN JJ I-NP O
@@ -39973,8 +39973,8 @@ were VBD I-VP O
 declared VBN I-VP O
 official NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-GLADISHIVA NNP I-NP B-PER
@@ -40027,8 +40027,8 @@ to TO B-PP O
 provisional JJ I-NP O
 results NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 GOLF NN I-NP O
 - : O O
@@ -40189,8 +40189,8 @@ off IN I-PP O
 the DT I-NP O
 pace NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-WOMEN JJ I-NP O
@@ -40287,8 +40287,8 @@ World NNP I-NP B-MISC
 Cup NNP I-NP I-MISC
 victor NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-WOMEN JJ I-NP O
@@ -40880,8 +40880,8 @@ Russia NNP I-NP B-LOC
 United NNP I-NP B-LOC
 States NNP I-NP I-LOC
 164 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-WOMEN JJ I-NP O
@@ -41163,8 +41163,8 @@ were VBD I-VP O
 declared VBN I-VP O
 official NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NORDIC NNP I-NP O
 SKIING-WORLD NNP I-NP B-MISC
@@ -41357,8 +41357,8 @@ Paramygina NNP I-NP B-PER
 3. NNP I-NP O
 Greiner-Petter-Memm NNP I-NP B-PER
 78 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-GOETCHL NNP I-NP B-PER
@@ -41408,8 +41408,8 @@ Italy NNP I-NP B-LOC
 took VBD I-VP O
 third JJ I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BOBSLEIGH-SHIMER NNP I-NP B-PER
 PILOTS NNP I-NP O
@@ -41590,8 +41590,8 @@ place NN I-NP O
 on IN I-PP O
 Saturday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SKIING-CHINESE JJ I-NP B-MISC
 MAKE VB I-VP O
@@ -41845,8 +41845,8 @@ Leu NNP I-NP I-PER
 with IN I-PP O
 160.36 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BOBSLEIGH-WORLD NNP I-NP B-MISC
 CUP NNP I-NP I-MISC
@@ -42074,8 +42074,8 @@ Kuttner NNP I-NP I-PER
 53.30/ CD I-NP O
 
 53.04). CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -42379,8 +42379,8 @@ will MD I-VP O
 be VB I-VP O
 played VBN I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 FREESTYLE NNP I-NP O
 SKIING-WORLD NNP I-NP B-MISC
@@ -42575,8 +42575,8 @@ Lid NNP I-NP I-PER
 Norway NNP I-NP B-LOC
 ) ) O O
 148.20 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SKI NNS I-NP O
 JUMPING-LEADING NN I-NP O
@@ -42806,8 +42806,8 @@ Peterka NNP I-NP I-PER
 Slovakia NNP I-NP B-LOC
 ) ) O O
 76 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BADMINTON NNP I-NP O
 - : O O
@@ -42903,8 +42903,8 @@ China NNP I-NP B-LOC
 ) ) O O
 11-8 CD I-NP O
 11-3 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SPEED JJ I-NP O
 SKATING-RESULTS NNS I-NP O
@@ -43339,8 +43339,8 @@ Rulhong NNP I-NP I-PER
 China NNP I-NP B-LOC
 ) ) O O
 1:25.89 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 ALPINE NNP I-NP O
 SKIING-OFFICIALS NNP I-NP O
@@ -43530,8 +43530,8 @@ likely RB I-VP O
 be VB I-VP O
 abandoned VBN I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -43661,8 +43661,8 @@ Canio NNP I-NP I-PER
 Celtic NNP I-NP B-ORG
 ) ) O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -43804,8 +43804,8 @@ Beardsley NNP I-NP I-PER
 Newcastle NNP I-NP B-ORG
 ) ) O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -43947,8 +43947,8 @@ Cliftonville VB I-VP B-ORG
 5 CD I-NP O
 12 CD I-NP O
 7 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RUGBY NNP I-NP B-ORG
 UNION NN I-NP I-ORG
@@ -44050,8 +44050,8 @@ Boroughmuir NNP I-NP B-ORG
 31 CD I-NP O
 Watsonians NNP I-NP B-ORG
 35 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -44186,8 +44186,8 @@ McGinlay NNP I-NP B-PER
 
 48,053 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RUGBY NNP I-NP B-ORG
 UNION NN I-NP I-ORG
@@ -44381,8 +44381,8 @@ jersey NN I-NP O
 he PRP I-NP O
 said VBD I-VP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -44567,8 +44567,8 @@ Holdsworth NNP I-NP B-PER
 
 19,672 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -44993,8 +44993,8 @@ Stirling NNP I-NP I-ORG
 14 CD I-NP O
 25 CD I-NP O
 11 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -45893,8 +45893,8 @@ Brighton NN I-NP B-ORG
 18 CD I-NP O
 42 CD I-NP O
 13 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -46059,8 +46059,8 @@ by IN I-PP O
 four CD I-NP O
 points NNS I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -46225,8 +46225,8 @@ on IN I-PP O
 December NNP I-NP O
 14 CD I-NP O
 ) ) O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -46477,8 +46477,8 @@ Cardiff NNP I-NP B-ORG
 0 CD I-NP O
 Gillingham NNP I-NP B-ORG
 2 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RUGBY NNP I-NP B-ORG
 UNION NN I-NP I-ORG
@@ -46633,8 +46633,8 @@ aggregate NN I-NP O
 to TO I-PP O
 136 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 RUGBY NNP I-NP B-ORG
 UNION NN I-NP I-ORG
@@ -46724,8 +46724,8 @@ Conversion NNP I-NP O
 Rob NNP I-NP B-PER
 Andrew NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 GOLF NN I-NP O
 - : O O
@@ -46940,8 +46940,8 @@ Botes NNPS I-NP I-PER
 68 CD I-NP O
 74 CD B-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -47173,8 +47173,8 @@ Vata NNP I-NP I-PER
 Erjon NNP I-NP B-PER
 Bogdani NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -47372,8 +47372,8 @@ for IN I-PP O
 for IN I-PP O
 Victoria NNP I-NP B-ORG
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 CRICKET NNP I-NP O
 - : O O
@@ -47444,8 +47444,8 @@ not RB I-VP O
 out RP I-PRT O
 ) ) O O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -47881,8 +47881,8 @@ Kim NNP I-NP B-PER
 Joo NNP I-NP I-PER
 Sung NNP I-NP I-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -48161,8 +48161,8 @@ Aviv NNP I-NP I-ORG
 7 CD I-NP O
 16 CD I-NP O
 9 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -48335,8 +48335,8 @@ Indonesia NNP I-NP B-LOC
 4 CD I-NP O
 6 CD I-NP O
 1 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NBA NNP I-NP B-ORG
 BASKETBALL NNP I-NP O
@@ -48655,8 +48655,8 @@ DENVER NN I-NP B-LOC
 CHARLOTTE NNP I-NP B-ORG
 AT NNP I-NP O
 SEATTLE NNP I-NP B-LOC
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NBA NNP I-NP B-ORG
 BASKETBALL NNP I-NP O
@@ -48739,8 +48739,8 @@ LAKERS NNS I-NP I-ORG
 92 CD B-NP O
 Orlando NNP I-NP B-ORG
 81 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NHL NNP I-NP B-ORG
 ICE NNP I-NP O
@@ -49101,8 +49101,8 @@ JOSE NNP I-NP I-LOC
 OTTAWA NNP I-NP B-ORG
 AT NNP I-NP O
 VANCOUVER NNP I-NP B-LOC
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NHL NNP I-NP B-ORG
 ICE NNP I-NP O
@@ -49173,8 +49173,8 @@ EDMONTON NN I-NP B-ORG
 5 CD I-NP O
 Ottawa NNP I-NP B-ORG
 2 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 NHL NNP I-NP B-ORG
 ICE NNP I-NP O
@@ -49383,8 +49383,8 @@ game NN I-NP O
 against IN I-PP O
 Ottawa NNP I-NP B-ORG
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 BOXING VBG I-VP O
 - : O O
@@ -49420,8 +49420,8 @@ fight NN I-NP O
 on IN I-PP O
 Saturday NNP I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -49467,8 +49467,8 @@ Halftime VB I-VP O
 Attendance NNP I-NP O
 106,000 CD I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -49616,8 +49616,8 @@ Brazilian JJ I-NP B-MISC
 striker NN I-NP O
 Ronaldo NNP B-NP B-PER
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -49800,8 +49800,8 @@ in IN I-PP O
 the DT I-NP O
 table NN I-NP O
 . . O O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O
@@ -50064,8 +50064,8 @@ Extremadura NNP I-NP B-ORG
 8 CD I-NP O
 30 CD B-NP O
 6 CD I-NP O
--DOCSTART- -X- -X- O
 
+-DOCSTART- -X- -X- O
 
 SOCCER NN I-NP O
 - : O O


### PR DESCRIPTION
There was an error when preprocessing the DOCSTART boundaries in this dataset. A fix was pushed in the original repo (https://github.com/ZihanWangKi/CrossWeigh/pull/4). Extremely sorry that I forgot a separate file was maintained here, so I am copying the corrected file.